### PR TITLE
Fixing Compilation Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 project(zuckerli)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/src/bit_writer.h
+++ b/src/bit_writer.h
@@ -23,16 +23,16 @@ namespace zuckerli {
 // systems.
 class BitWriter {
  public:
-  static constexpr size_t kMaxBitsPerCall = 56;
+  static constexpr std::size_t kMaxBitsPerCall = 56;
 
-  void Write(size_t nbits, size_t bits);
+  void Write(std::size_t nbits, std::size_t bits);
 
-  size_t NumBitsWritten() { return bits_written_; }
+  std::size_t NumBitsWritten() { return bits_written_; }
 
   // Required before calls to write.
-  void Reserve(size_t nbits);
+  void Reserve(std::size_t nbits);
 
-  void AppendAligned(const uint8_t *ptr, size_t cnt);
+  void AppendAligned(const uint8_t *ptr, std::size_t cnt);
 
   void ZeroPad() { bits_written_ = (bits_written_ + 7) / 8 * 8; }
 
@@ -40,7 +40,7 @@ class BitWriter {
 
  private:
   std::vector<uint8_t> data_;
-  size_t bits_written_ = 0;
+  std::size_t bits_written_ = 0;
 };
 }  // namespace zuckerli
 


### PR DESCRIPTION
Changed to C++ 14 to comply with abseil requirements and switched from size_t to std::size_t